### PR TITLE
network events were not getting inserted

### DIFF
--- a/core/network.py
+++ b/core/network.py
@@ -102,8 +102,7 @@ def new_network_events(configuration):
                 if len(line) > 0:
                     # split the IP and Port
                     try:
-                        ip, port = line.rsplit()[0], int(line.rsplit()[1])
-                        ip=ip.decode('utf-8')
+                        ip, port = str(line.rsplit()[0].decode()), int(line.rsplit()[1])
                     except Exception as _:
                         ip, port = None, None
                     # check if event shows an IP

--- a/core/network.py
+++ b/core/network.py
@@ -103,6 +103,7 @@ def new_network_events(configuration):
                     # split the IP and Port
                     try:
                         ip, port = line.rsplit()[0], int(line.rsplit()[1])
+                        ip=ip.decode('utf-8')
                     except Exception as _:
                         ip, port = None, None
                     # check if event shows an IP


### PR DESCRIPTION
PR for https://github.com/zdresearch/OWASP-Honeypot/issues/10
what : in the ip split it is return type bytes and the netaddr.valid_ipv4 or
ipv6 needs a string as an ip so i converted the ip
@Ali-Razmjoo : please review 