### PR TITLE
only support latest version of python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,8 @@
 language: python
+dist: xenial
 
 python:
- - "2.6"
- - "2.7"
- - "3.4"
- - "3.5"
- - "3.6"
- - "3.7-dev"
+ - "3.7"
 
 os:
  - "linux"


### PR DESCRIPTION
I've removed the travis ci old python version, don't need to test them anymore. I will dockerize it later!