### PR TITLE
Fix path for SSH key path

### DIFF
--- a/lib/modules/ssh/weak_password/Dockerfile
+++ b/lib/modules/ssh/weak_password/Dockerfile
@@ -11,7 +11,7 @@ RUN echo {username}:{password} | /usr/sbin/chpasswd
 RUN python -c "f=open(\"/etc/ssh/sshd_config\").read().replace(\"#Port 22\",\"Port 22\").replace(\"#PermitRootLogin yes\",\"PermitRootLogin yes\"); z = open(\"/etc/ssh/sshd_config\", \"w\");z.write(f); z.close(); print \"fixed sshd_config\""
 
 # run ssh-keygen non-interactive
-RUN ssh-keygen -k -f id_rsa -t rsa -N '' && service ssh restart
+RUN ssh-keygen -k -f id_rsa -t rsa -N '' -f /root/.ssh/id_rsa >/dev/null && service ssh restart
 
 # start the service + wait for container
 ENTRYPOINT service ssh restart && tail


### PR DESCRIPTION
This PR fixes the path for the SSH key that is been generated. Before this PR the path for `id_rsa.pub` and `id_rsa` was `/` and I think it should've been `/root/.ssh/` so I fixed that. 