### PR TITLE
added kill flag to ssh keygen 

### DIFF
--- a/lib/modules/ssh/weak_password/Dockerfile
+++ b/lib/modules/ssh/weak_password/Dockerfile
@@ -11,7 +11,7 @@ RUN echo {username}:{password} | /usr/sbin/chpasswd
 RUN python -c "f=open(\"/etc/ssh/sshd_config\").read().replace(\"#Port 22\",\"Port 22\").replace(\"#PermitRootLogin yes\",\"PermitRootLogin yes\"); z = open(\"/etc/ssh/sshd_config\", \"w\");z.write(f); z.close(); print \"fixed sshd_config\""
 
 # run ssh-keygen non-interactive
-RUN ssh-keygen -f id_rsa -t rsa -N '' && service ssh restart
+RUN ssh-keygen -k -f id_rsa -t rsa -N '' && service ssh restart
 
 # start the service + wait for container
 ENTRYPOINT service ssh restart && tail


### PR DESCRIPTION
travis CI is waiting forever because ssh keygen isn't killed and that's why build is failing.
As suggested https://github.com/travis-ci/travis-ci/issues/8082 added kill flag to ssh-keygen