### PR TITLE
replaced socket.gethostname()

### DIFF
--- a/config.py
+++ b/config.py
@@ -6,7 +6,7 @@ import socket
 from core.time_helper import hours
 from core.compatible import generate_token
 
-real_machine_ip_address = socket.gethostbyname(socket.gethostname())
+real_machine_ip_address = socket.gethostbyname("")
 
 
 def api_configuration():


### PR DESCRIPTION
worked on issue #40 

fixes
Not printing logo on macOS in
OWASP-Honeypot/config.py

Proposed:
Replace socket.gethostname() with ""

Testing:

![Screenshot 2020-02-23 at 12 01 24 PM](https://user-images.githubusercontent.com/53293156/75104883-3c68a300-5634-11ea-856f-9f9fec5a8554.png)
