### PR TITLE
Early check for root privileges. 

### DIFF
--- a/core/compatible.py
+++ b/core/compatible.py
@@ -59,7 +59,7 @@ def version():
     """
     return int(sys.version_info[0])
 
-def promt_sudo():
+def prompt_sudo():
     """
     Promt to enter root password
 

--- a/core/compatible.py
+++ b/core/compatible.py
@@ -59,6 +59,18 @@ def version():
     """
     return int(sys.version_info[0])
 
+def promt_sudo():
+    """
+    Promt to enter root password
+
+    Returns:
+        0 if password entered successfully
+    """
+    ret = 0
+    if os.geteuid != 0:
+        msg = "[sudo] password for %u: "
+        ret = subprocess.check_call(["sudo","-v","-p",msg])
+    return ret
 
 def check(language):
     """

--- a/core/load.py
+++ b/core/load.py
@@ -31,6 +31,7 @@ from core.compatible import check_for_requirements
 from core.compatible import copy_dir_tree
 from core.compatible import mkdir
 from core.compatible import get_module_dir_path
+from core.compatible import promt_sudo
 from database.connector import insert_bulk_events_from_thread
 from database.connector import insert_events_in_bulk
 
@@ -618,6 +619,9 @@ def load_honeypot_engine():
     # print logo
     logo()
 
+    # Ask for sudo password if not root user
+    if promt_sudo()!= 0:
+        return
     # parse argv
     parser, argv_options = argv_parser()
 

--- a/core/load.py
+++ b/core/load.py
@@ -31,7 +31,7 @@ from core.compatible import check_for_requirements
 from core.compatible import copy_dir_tree
 from core.compatible import mkdir
 from core.compatible import get_module_dir_path
-from core.compatible import promt_sudo
+from core.compatible import prompt_sudo
 from database.connector import insert_bulk_events_from_thread
 from database.connector import insert_events_in_bulk
 
@@ -620,7 +620,7 @@ def load_honeypot_engine():
     logo()
 
     # Ask for sudo password if not root user
-    if promt_sudo()!= 0:
+    if prompt_sudo()!= 0:
         return
     # parse argv
     parser, argv_options = argv_parser()


### PR DESCRIPTION
Sometimes when running the program without sudo, it runs for a while and starts various containers and exits as tshark needs root privileges. To save some time I added a prompt for sudo in the beginning itself. 

Tested for MacOS.